### PR TITLE
Pin tj-actions/changed-files to SHA (v47.0.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Get modified CRDs
         id: modified-crds
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
         with:
           files: |
             package/crds/**


### PR DESCRIPTION
## Summary

- Replace mutable tag reference `tj-actions/changed-files@v45` with SHA-pinned `@22103cc46bda19c2b464ffe86db46df6922fd323` (v47.0.5)

## Context

`tj-actions/changed-files` was compromised in March 2025 ([GHSA-mrrh-fwg8-r2c3](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3)). The attacker retroactively rewrote version tags to point to a malicious commit that extracted CI secrets from runner process memory and printed them to workflow logs.

This repo was created after the compromise window (April 2025) and was not affected. However, the `@v45` tag is a mutable reference -- if the action were compromised again, the same attack vector would apply. SHA pinning prevents mutable tag rewriting from affecting this workflow.

Additionally, `@v45` is outdated -- the current release is v47.0.5.

## What changed

Single line change in `.github/workflows/ci.yml`:

```yaml
# Before
uses: tj-actions/changed-files@v45

# After
uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
```

## Test plan

- [ ] CI passes with the updated action reference
- [ ] `report-breaking-changes` job still detects modified CRDs correctly