### PR TITLE
chore: standardise le formatting Go (gofumpt)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -116,11 +116,9 @@ issues:
   new: false
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
   settings:
-    gofmt:
-      simplify: true
     goimports:
       local-prefixes:
         - github.com/crossplane/upjet-provider-template

--- a/internal/controller/namespaced/providerconfig/config.go
+++ b/internal/controller/namespaced/providerconfig/config.go
@@ -21,7 +21,6 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 		return err
 	}
 	return setupClusterProviderConfig(mgr, o)
-
 }
 
 func setupNamespacedProviderConfig(mgr ctrl.Manager, o controller.Options) error {


### PR DESCRIPTION
## Quoi

Standardisation du formatting Go du provider, dans le cadre de la généralisation du formatting de l'équipe Plateforme.

- Activation du formatter **gofumpt** dans `.golangci.yml` (config golangci-lint v2, section `formatters.enable`).
- Suppression du réglage `formatters.settings.gofmt.simplify` devenu redondant : gofumpt englobe `gofmt -s`.
- `goimports` conservé.
- Reformatage one-shot via `golangci-lint fmt` (version alignée sur la CI, v2.4.0).

## Lock CI

Pas de nouveau workflow : le step `golangci-lint` du `ci.yml` existant vérifie déjà les formatters de la config v2. Dès que gofumpt est activé, il échoue sur tout code non formaté → le format est verrouillé en CI.

## Périmètre du reformatage

Le one-shot ne touche qu'un fichier écrit à la main (suppression d'une ligne vide en fin de bloc). Aucun code généré (`zz_*.go`) ni le submodule `build/` n'est modifié — les exclusions `generated: lax` les couvrent.

Refs Evaneos/team-platform#279

🤖 Generated with [Claude Code](https://claude.com/claude-code)